### PR TITLE
fix: Prevent early audio cutoff due to NaN values

### DIFF
--- a/src/SoundTouchWorklet.js
+++ b/src/SoundTouchWorklet.js
@@ -52,6 +52,11 @@ class SoundTouchWorklet extends AudioWorkletProcessor {
     for (let i = 0; i < leftInput.length; i++) {
       leftOutput[i] = processedSamples[i * 2];
       rightOutput[i] = processedSamples[i * 2 + 1];
+
+      if (isNaN(leftOutput[i]) || isNaN(rightOutput[i])) {
+        leftOutput[i] = 0;
+        rightOutput[i] = 0;
+      }
     }
 
     return true;


### PR DESCRIPTION
Hello,

I tested the new standalone AudioWorkletProcessor of SoundtouchJS and encountered an issue where SoundTouch produces NaN values in the output buffer.

This causes the audio to cut off early and produce a glitch sound.

The fix is simple: when we encounter NaN values in the output, we replace them with zero.

This prevents the audio cutoff. I have tested this fix on several audio files, particularly with pitch = 0.25, and it works reliably.

The fix is similar to the one in PR #20.